### PR TITLE
Add explicit :any types to typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,14 +13,14 @@ declare namespace NodeSyncIpc{
 
     interface NodeSyncIpcChildProcess extends child_process.ChildProcess{
 
-        onSync(event:string,listener:(res:(returnValue?)=>void,...args:any[])=>void);
+        onSync(event:string,listener:(res:(returnValue?:any)=>void,...args:any[])=>void):any;
 
     }
 
 
     interface NodeSyncIpcChild{
 
-        sendSync(event:string,...args:any[]);
+        sendSync(event:string,...args:any[]):any;
 
     }
 


### PR DESCRIPTION
This avoids errors when compiling w/ `noImplicitAny` on:

```
node_modules/node-sync-ipc/index.d.ts(16,9): error TS7010: 'onSync', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/node-sync-ipc/index.d.ts(16,44): error TS7006: Parameter 'returnValue' implicitly has an 'any' type.
node_modules/node-sync-ipc/index.d.ts(23,9): error TS7010: 'sendSync', which lacks return-type annotation, implicitly has an 'any' return type.
```